### PR TITLE
Fixed flexible filament restart function.

### DIFF
--- a/Sylinder/Sylinder.cpp
+++ b/Sylinder/Sylinder.cpp
@@ -74,6 +74,8 @@ void Sylinder::writePVTP(const std::string &prefix, const std::string &postfix, 
     std::vector<IOHelper::FieldVTU> cellDataFields;
     cellDataFields.emplace_back(1, IOHelper::IOTYPE::Int32, "gid");
     cellDataFields.emplace_back(1, IOHelper::IOTYPE::Int32, "group");
+    cellDataFields.emplace_back(1, IOHelper::IOTYPE::Int32, "prevLink");
+    cellDataFields.emplace_back(1, IOHelper::IOTYPE::Int32, "nextLink");
     cellDataFields.emplace_back(1, IOHelper::IOTYPE::Float32, "radius");
     cellDataFields.emplace_back(1, IOHelper::IOTYPE::Float32, "radiusCollision");
     cellDataFields.emplace_back(1, IOHelper::IOTYPE::Float32, "length");
@@ -124,6 +126,7 @@ void Sylinder::writeAscii(FILE *fptr) const {
     Evec3 direction = ECmapq(orientation) * Evec3(0, 0, 1);
     Evec3 minus = ECmap3(pos) - 0.5 * length * direction;
     Evec3 plus = ECmap3(pos) + 0.5 * length * direction;
-    fprintf(fptr, "C %d %g %g %g %g %g %g %g %d %d %d\n", gid, radius, minus[0], minus[1], minus[2], plus[0], plus[1],
+    char typeChar = link.group == GEO_INVALID_INDEX ? 'C' : 'F'; 
+    fprintf(fptr, "%c %d %g %g %g %g %g %g %g %d %d %d\n", typeChar, gid, radius, minus[0], minus[1], minus[2], plus[0], plus[1],
             plus[2], link.group, link.prev, link.next);
 }

--- a/Sylinder/Sylinder.hpp
+++ b/Sylinder/Sylinder.hpp
@@ -239,6 +239,8 @@ class Sylinder {
         std::vector<float> length(sylinderNumber);
         std::vector<float> lengthCollision(sylinderNumber);
         std::vector<int> group(sylinderNumber);
+        std::vector<int> prevLink(sylinderNumber);
+        std::vector<int> nextLink(sylinderNumber);
 
         // vel
         std::vector<float> vel(3 * sylinderNumber);
@@ -292,6 +294,8 @@ class Sylinder {
             // sylinder data
             gid[i] = sy.gid;
             group[i] = sy.link.group;
+            prevLink[i] = sy.link.prev;
+            nextLink[i] = sy.link.next;
             radius[i] = sy.radius;
             radiusCollision[i] = sy.radiusCollision;
             length[i] = sy.length;
@@ -350,6 +354,8 @@ class Sylinder {
         file << "<CellData Scalars=\"scalars\">\n";
         IOHelper::writeDataArrayBase64(gid, "gid", 1, file);
         IOHelper::writeDataArrayBase64(group, "group", 1, file);
+        IOHelper::writeDataArrayBase64(prevLink, "prevLink", 1, file);
+        IOHelper::writeDataArrayBase64(nextLink, "nextLink", 1, file);
         IOHelper::writeDataArrayBase64(radius, "radius", 1, file);
         IOHelper::writeDataArrayBase64(radiusCollision, "radiusCollision", 1, file);
         IOHelper::writeDataArrayBase64(length, "length", 1, file);

--- a/Sylinder/Sylinder.hpp
+++ b/Sylinder/Sylinder.hpp
@@ -48,6 +48,7 @@ class Sylinder {
     double lengthCollision; ///< length for collision resolution
     double radiusSearch;    ///< radiusSearch for short range interactions
     double sepmin;          ///< minimal separation with its neighbors within radiusSearch
+    double colbuf;          ///< collision buffer factor
 
     double tg;
     double t;

--- a/Sylinder/SylinderSystem.cpp
+++ b/Sylinder/SylinderSystem.cpp
@@ -316,21 +316,21 @@ void SylinderSystem::setInitialFromFile(const std::string &filename) {
                 double px, py, pz;
                 double radius;
                 liness >> gid >> radius >> mx >> my >> mz >> px >> py >> pz;
-                                    Emap3(newBody.pos) = Evec3((mx + px) / 2, (my + py) / 2, (mz + pz) / 2);
+                Emap3(newBody.pos) = Evec3((mx + px) / 2, (my + py) / 2, (mz + pz) / 2);
                 newBody.gid = gid;
                 newBody.length = sqrt((px - mx) * (px - mx) + (py - my) * (py - my) + (pz - mz) * (pz - mz));
                 Evec3 direction(px - mx, py - my, pz - mz);
                 Emapq(newBody.orientation) = Equatn::FromTwoVectors(Evec3(0, 0, 1), direction);
                 newBody.radius = radius;
-                newBody.radiusCollision = radius; 
+                newBody.radiusCollision = radius;
                 newBody.lengthCollision = newBody.length;
 
                 Link link;
-                if(typeChar == 'F'){ //Make sylinder a link in a flexible filament
+                if (typeChar == 'F') { // Make sylinder a link in a flexible filament
                     int link_grp, prev_link, next_link;
                     liness >> link_grp >> prev_link >> next_link;
                     link.group = link_grp;
-                    link.prev = prev_link; 
+                    link.prev = prev_link;
                     link.next = next_link;
                 }
                 newBody.link = link;
@@ -377,7 +377,7 @@ void SylinderSystem::setInitialFromVTKFile(const std::string &pvtpFileName) {
         vtkSmartPointer<vtkDataArray> gidData = polydata1->GetCellData()->GetArray("gid");
         vtkSmartPointer<vtkDataArray> groupData = polydata1->GetCellData()->GetArray("group");
         vtkSmartPointer<vtkDataArray> prevLinkData = polydata1->GetCellData()->GetArray("prevLink");
-        vtkSmartPointer<vtkDataArray> nextLinkData= polydata1->GetCellData()->GetArray("nextLink");
+        vtkSmartPointer<vtkDataArray> nextLinkData = polydata1->GetCellData()->GetArray("nextLink");
 
         vtkSmartPointer<vtkDataArray> lengthData = polydata1->GetCellData()->GetArray("length");
         vtkSmartPointer<vtkDataArray> lengthCollisionData = polydata1->GetCellData()->GetArray("lengthCollision");
@@ -871,6 +871,7 @@ void SylinderSystem::prepareStep() {
         sy.radiusCollision = sylinderContainer[i].radius * runConfig.sylinderDiameterColRatio;
         sy.lengthCollision = sylinderContainer[i].length * runConfig.sylinderLengthColRatio;
         sy.rank = commRcp->getRank();
+        sy.colbuf = runConfig.sylinderColBuf;
     }
     if (runConfig.monolayer) {
         const double monoZ = (runConfig.simBoxHigh[2] + runConfig.simBoxLow[2]) / 2;


### PR DESCRIPTION
Previously, flexible filaments would restart without segments linked together because prev and next link IDs were not passed through VTK files. This commit fixes that.